### PR TITLE
design database

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,24 +1,74 @@
-# README
+## Usersテーブル
+|column      |  type|option               |
+|:-----------|-----------|-----------:|
+|id               |*integer*|null false   |
+|username         | *string*|null false  ※add_index |
+|email |*string*|null false               |
+|password| *string*|null false            |
+|confirm password |*string*|null false    |
+|avatar |*string*|           |
+|profile|*text*|   |
+|position|*string*|    |
+|occupation|*string*|      |
 
-This README would normally document whatever steps are necessary to get the
-application up and running.
+#### association
+    has_many :protos
+    has_many :likes
 
-Things you may want to cover:
 
-* Ruby version
 
-* System dependencies
+## Protosテーブル
+|column      |  type|option|
+|:-----------|-----------|-----------:|
+|id |*integer*|null false|
+|title| *string*|null false ※add_index|
+|catchcopy| *string*|null false|
+|concept| *text*|null false|
+|user_id |*integer*|null false|
 
-* Configuration
+#### association
+    has_many :likes
+    has_many :images
+    belongs_to :user
 
-* Database creation
 
-* Database initialization
 
-* How to run the test suite
+## Likesテーブル
+|column      |  type|option           |
+|:-----------|-----------|-----------:|
+|id |*integer*|null false             |
+|user_id |*integer*|null false  ※add_index |
+|proto_id |*integer*|null false  ※add_index |
 
-* Services (job queues, cache servers, search engines, etc.)
+#### association
+    belongs_to :user
+    belongs_to :proto
 
-* Deployment instructions
 
-* ...
+
+## imagesテーブル
+|column      |  type|option|
+|:-----------|-----------|-----------:|
+|id |*integer*|null false|
+|image |*string*|null false|
+|proto_id |*integer*|null false|
+|role | *integer*|null false, default: 0 ※add_index|
+
+#### association
+    belongs_to :proto
+
+#### enum
+    enum role: { sub: 0, main: 1 }
+
+
+## commentsテーブル
+|column      |  type|option|
+|:-----------|-----------|-----------:|
+|id |*integer*|null false|
+|text|*text*|null false|
+|user_id |*integer*|null false|
+|proto_id | *integer*|null false|
+
+#### association
+    belongs_to :user
+    belongs_to :proto


### PR DESCRIPTION
# what
データベースの設計
# why
実際に記述する上でわかりやすくするため
# how
・imagesがsubかmainかを判断するために、enumでroleと設定した。fields_forのhidden_fieldでどちらか分けて送ってしまう
・Usersのusernameカラム、protoのtitleカラム、likesの外部キーそれぞれにindexを貼った
・null: falseはtomato-spaceの仕様を参考にして設定した